### PR TITLE
Update homepage with fair pricing positioning

### DIFF
--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -1,23 +1,23 @@
 <!DOCTYPE html><html lang="en" class="scroll-smooth"><head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AWS Cost Optimization: Save 20-55% with Zero Lock-In | RightSpend</title>
+    <title>AWS Cost Optimization: Only Pay for Net New Savings | RightSpend</title>
 
     <!-- SEO Meta Tags -->
-    <meta name="description" content="Stop overpaying for AWS. RightSpend's Commitment Free Discounts save you 20-55% on EC2 with no 3-year lock-in. See how much you'll save in 60 seconds.">
+    <meta name="description" content="Most AWS cost tools charge for savings you were already getting. RightSpend only charges for net new savings we find. 20-55% savings. Risk-free trial. No lock-in.">
     <meta name="keywords" content="RightSpend, CloudFix, Commitment Free Discounts, CFDs, EC2 savings, AWS cost optimization, Reserved Instances, Savings Plans, FinOps, cRIs, AWS Marketplace, RightSpend Flex, discount rate, coverage optimization">
     <meta name="author" content="CloudFix">
 
     <!-- Open Graph / Social Media Meta Tags -->
-    <meta property="og:title" content="RightSpend: Commitment Free Discounts for AWS EC2 | CloudFix">
-    <meta property="og:description" content="RightSpend delivers Commitment Free Discounts (CFDs) for AWS EC2 - up to 55% savings vs on-demand. No lock-in, works with existing Savings Plans &amp; Reserved Instances.">
+    <meta property="og:title" content="RightSpend: AWS Cost Optimization That Only Charges for Net New Savings">
+    <meta property="og:description" content="Most AWS cost tools charge for savings you were already getting. RightSpend only charges for net new savings we find. 20-55% savings. Risk-free trial.">
     <meta property="og:url" content="https://rightspend.ai">
     <meta property="og:image" content="/assets/images/RightSpend-cool.png">
 
     <!-- Twitter Card Tags -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="RightSpend: Commitment Free Discounts for AWS EC2">
-    <meta name="twitter:description" content="Up to 55% AWS EC2 savings with Commitment Free Discounts. No lock-in, works with existing Savings Plans &amp; Reserved Instances.">
+    <meta name="twitter:title" content="RightSpend: Only Pay for Net New AWS Savings">
+    <meta name="twitter:description" content="Most tools take credit for your existing savings. We only charge for net new savings we find. Risk-free trial. No lock-in.">
     <meta name="twitter:image" content="/assets/images/RightSpend-cool.png">
     
     <!-- Canonical URL -->
@@ -44,7 +44,7 @@
       "name": "RightSpend",
       "applicationCategory": "Cloud Cost Optimization Software",
       "operatingSystem": "AWS Cloud",
-      "description": "RightSpend delivers Commitment Free Discounts (CFDs) for AWS EC2 with up to 55% savings vs on-demand pricing. No lock-in periods, works with existing Savings Plans and Reserved Instances.",
+      "description": "RightSpend is the only AWS cost optimization tool that only charges for net new savings. Most tools take credit for savings you were already getting. We don't. 20-55% savings. Risk-free trial. No lock-in.",
       "url": "https://rightspend.ai",
       "author": {
         "@type": "Organization",
@@ -599,10 +599,10 @@
             <div class="flex flex-col md:flex-row items-center justify-between">
                 <div class="md:w-1/2 mb-12 md:mb-0">
                     <h1 class="text-4xl md:text-5xl font-bold mb-6" data-aos="fade-up">
-                        Enterprise AWS Cost Optimization Platform
+                        AWS Cost Optimization That Only Charges for Net New Savings
                     </h1>
                     <p class="text-xl text-gray-600 mb-8 definition-block" data-aos="fade-up" data-aos-delay="100" data-term="AWS Cost Optimization">
-                        <strong>Complete AWS Cost Optimization:</strong> Automated discount management, FinOps governance, and flexible savings strategies. Reduce AWS costs by 20-55% with enterprise-grade transparency and control.
+                        <strong>Fair pricing for AWS savings:</strong> Most tools take credit for savings you were already getting. RightSpend only charges for <em>net new</em> savings we find for you. Risk-free trial. No lock-in. 20-55% savings.
                     </p>
                     <div class="flex flex-col sm:flex-row gap-4" data-aos="fade-up" data-aos-delay="200">
                         <a href="https://rightspend.ai/aws-savings-calculator.html" class="btn-primary text-lg">Calculate Your Savings</a>
@@ -702,6 +702,53 @@
                     <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
                     </svg>
+                </a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Fair Pricing Differentiator Section -->
+    <section class="py-20 bg-gradient-to-r from-blue-50 to-indigo-50">
+        <div class="container mx-auto px-6">
+            <div class="max-w-4xl mx-auto text-center" data-aos="fade-up">
+                <h2 class="text-3xl md:text-4xl font-bold mb-6">
+                    Why RightSpend Pricing Is Fairer
+                </h2>
+                <p class="text-xl text-gray-700 mb-12">
+                    Most AWS cost optimization tools take credit for <strong>savings you were already getting</strong>. We don't.
+                </p>
+            </div>
+
+            <div class="grid md:grid-cols-2 gap-8 max-w-5xl mx-auto">
+                <!-- The Problem -->
+                <div class="bg-white p-8 rounded-lg shadow-sm border-l-4 border-red-400" data-aos="fade-right">
+                    <h3 class="text-xl font-bold mb-4 text-red-600">⚠️ The Industry Problem</h3>
+                    <p class="text-gray-700 mb-4">
+                        Other tools charge a percentage of your <strong>total</strong> AWS spend or total savings — including savings from Reserved Instances and Savings Plans you already had.
+                    </p>
+                    <p class="text-gray-600 text-sm">
+                        <em>They take credit for your existing work. You pay for savings you were already getting.</em>
+                    </p>
+                </div>
+
+                <!-- The RightSpend Way -->
+                <div class="bg-white p-8 rounded-lg shadow-sm border-l-4 border-green-500" data-aos="fade-left">
+                    <h3 class="text-xl font-bold mb-4 text-green-600">✓ The RightSpend Way</h3>
+                    <p class="text-gray-700 mb-4">
+                        We only charge for <strong>net new savings</strong> we find for you. If you already have RIs or Savings Plans saving you money, we don't take credit for those.
+                    </p>
+                    <p class="text-gray-600 text-sm">
+                        <em>You only pay for actual new value we deliver. Fair and simple.</em>
+                    </p>
+                </div>
+            </div>
+
+            <div class="text-center mt-12" data-aos="fade-up">
+                <p class="text-lg text-gray-700 mb-6">
+                    <strong>Risk-free trial:</strong> If we don't find net new savings, you don't pay. No lock-in, ever.
+                </p>
+                <a href="https://cal.read.ai/bill-gleeson" class="btn-primary inline-block">
+                    Get Your Free AWS Audit →
                 </a>
             </div>
         </div>


### PR DESCRIPTION
## Overview

Updated the RightSpend homepage with new fair pricing positioning that emphasizes only charging for net new savings, unlike competitors who take credit for existing savings.

## Changes

### Hero Section
- **New title:** "AWS Cost Optimization That Only Charges for Net New Savings"
- **Updated description:** Emphasizes fair pricing model

### New Section Added
```html
<section class="py-20 bg-gradient-to-r from-blue-50 to-indigo-50">
  <h2>Why RightSpend Pricing Is Fairer</h2>
  
  <div class="bg-white p-8 rounded-lg border-l-4 border-red-400">
    <h3>⚠️ The Industry Problem</h3>
    <p>Other tools charge a percentage of your total AWS spend or total savings — including savings from Reserved Instances and Savings Plans you already had.</p>
  </div>
  
  <div class="bg-white p-8 rounded-lg border-l-4 border-green-500">
    <h3>✓ The RightSpend Way</h3>
    <p>We only charge for net new savings we find for you. If you already have RIs or Savings Plans saving you money, we don't take credit for those.</p>
  </div>
</section>
```

### Additional Updates
- Meta description and SEO tags
- Open Graph and Twitter Card metadata
- Schema.org structured data

## Positioning
**THE FAIR PRICING REBEL**
- Only charge for net new savings
- Don't take credit for existing RIs/Savings Plans
- Risk-free trial
- No lock-in

## Files Changed
- `src/pages/index.html`

## Preview
See the fair pricing positioning in action on the branch.